### PR TITLE
Ensure that maven uses java 1.8 when compiling and testing

### DIFF
--- a/main-module/pom.xml
+++ b/main-module/pom.xml
@@ -18,4 +18,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Hi Pete,

Please could you review this change to ensure that we are using java 1.8 for this repo.

Thanks,
James