### PR TITLE
Specify source encoding explicitly

### DIFF
--- a/main-module/pom.xml
+++ b/main-module/pom.xml
@@ -10,6 +10,10 @@
   <name>Java Test Project</name>
   <url>http://maven.apache.org</url>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -18,6 +22,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
So that you don't get a warning saying the build is platform specific.